### PR TITLE
Add laptop issue template: Correct syntax errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-laptop.yml
+++ b/.github/ISSUE_TEMPLATE/add-laptop.yml
@@ -32,7 +32,7 @@ body:
     validations:
       required: false
   - type: textarea
-    id: gpu(s)
+    id: gpus
     attributes:
       label: GPU(s)
       description: What GPU(s) can the laptop model be configured with? Also, if possible, include which type of graphics switching technology that the laptop includes.
@@ -45,8 +45,8 @@ body:
       label: Does the laptop have a MUX switch?
       multiple: false
       options:
-        - No
-        - Yes
+        - 'No'
+        - 'Yes'
   - type: textarea
     id: notes
     attributes:


### PR DESCRIPTION
Remove the parenthesis from the IDs inside the add laptop issue template form, since this is a syntax error. Similarly, wrap the boolean values with single quotes since this is against the syntax rules.

For more information, see: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#bodyi-id-can-only-contain-numbers-letters---_ and https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#bodyi-options-must-not-include-booleans-please-wrap-values-such-as-yes-and-true-in-quotes